### PR TITLE
[HCD9-427] Feedback

### DIFF
--- a/config/install/field.field.site_documentation.site_documentation.field_documentation_topics.yml
+++ b/config/install/field.field.site_documentation.site_documentation.field_documentation_topics.yml
@@ -13,7 +13,7 @@ entity_type: site_documentation
 bundle: site_documentation
 label: Topics
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -25,6 +25,6 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: false
+    auto_create: true
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/install/views.view.related_site_documents.yml
+++ b/config/install/views.view.related_site_documents.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.site_documentation.teaser
+    - field.storage.site_documentation.field_documentation_topics
     - taxonomy.vocabulary.documentation_topics
   module:
     - site_documentation
@@ -17,59 +18,23 @@ base_table: site_documentation_field_data
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Default
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-          contextual_filters_or: false
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 20
-          offset: 0
-      style:
-        type: default
-      row:
-        type: 'entity:site_documentation'
-        options:
-          relationship: none
-          view_mode: teaser
+      title: 'Related Site Documents'
       fields:
         name:
+          id: name
           table: site_documentation_field_data
           field: name
-          id: name
-          entity_type: null
-          entity_field: name
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -124,26 +89,29 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-      filters:
-        status:
-          value: '1'
-          table: site_documentation_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: site_documentation
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-      sorts: {  }
-      title: 'Related Site Documents'
-      header: {  }
-      footer: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 20
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
       empty: {  }
-      relationships: {  }
+      sorts: {  }
       arguments:
         field_documentation_topics_target_id:
           id: field_documentation_topics_target_id
@@ -152,6 +120,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           default_action: ignore
           exception:
             value: all
@@ -166,8 +135,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -177,9 +146,8 @@ display:
             type: none
             fail: 'not found'
           validate_options: {  }
-          break_phrase: false
+          break_phrase: true
           not: false
-          plugin_id: numeric
         id:
           id: id
           table: site_documentation_field_data
@@ -187,6 +155,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: site_documentation
+          entity_field: id
+          plugin_id: numeric
           default_action: default
           exception:
             value: all
@@ -200,8 +171,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -213,9 +184,39 @@ display:
           validate_options: {  }
           break_phrase: false
           not: true
+      filters:
+        status:
+          id: status
+          table: site_documentation_field_data
+          field: status
           entity_type: site_documentation
-          entity_field: id
-          plugin_id: numeric
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+      row:
+        type: 'entity:site_documentation'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+          contextual_filters_or: false
+      relationships: {  }
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -225,13 +226,13 @@ display:
         - url
       tags: {  }
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Related Documents'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
       display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -240,38 +241,158 @@ display:
         - url
       tags: {  }
   block_2:
-    display_plugin: block
     id: block_2
     display_title: 'All Site Documents'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      arguments: {  }
-      defaults:
-        arguments: false
-        filters: false
-        filter_groups: false
-        use_ajax: false
-        pager: false
-        empty: false
-        style: false
-        row: false
-        sorts: false
-      filters:
-        status:
-          value: '1'
+      fields:
+        name:
+          id: name
           table: site_documentation_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: site_documentation
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_documentation_topics:
+          id: field_documentation_topics
+          table: site_documentation__field_documentation_topics
+          field: field_documentation_topics
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: false
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p>There are no Documents with selected topic.</p>'
+            format: limited_html
+          tokenize: false
+      sorts:
         field_documentation_topics_target_id:
           id: field_documentation_topics_target_id
           table: site_documentation__field_documentation_topics
@@ -279,6 +400,50 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        name:
+          id: name
+          table: site_documentation_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: site_documentation
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: site_documentation_field_data
+          field: status
+          entity_type: site_documentation
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_documentation_topics_target_id:
+          id: field_documentation_topics_target_id
+          table: site_documentation__field_documentation_topics
+          field: field_documentation_topics_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -314,66 +479,50 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: documentation_topics
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      use_ajax: true
-      pager:
-        type: none
-        options:
-          offset: 0
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>There are no Documents with selected topic.</p>'
-            format: limited_html
-          plugin_id: text
       style:
         type: grid
         options:
-          uses_fields: false
+          grouping:
+            -
+              field: field_documentation_topics
+              rendered: true
+              rendered_strip: false
+          uses_fields: true
           columns: 4
           automatic_width: true
           alignment: horizontal
-          col_class_default: true
-          col_class_custom: ''
-          row_class_default: true
           row_class_custom: ''
+          row_class_default: true
+          col_class_custom: ''
+          col_class_default: true
       row:
         type: 'entity:site_documentation'
         options:
           relationship: none
           view_mode: teaser
-      sorts:
-        name:
-          id: name
-          table: site_documentation_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: site_documentation
-          entity_field: name
-          plugin_id: standard
+      defaults:
+        empty: false
+        use_ajax: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      use_ajax: true
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -381,4 +530,5 @@ display:
         - 'languages:language_interface'
         - url
         - user
-      tags: {  }
+      tags:
+        - 'config:field.storage.site_documentation.field_documentation_topics'

--- a/site_documentation.install
+++ b/site_documentation.install
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains install and update functions for site_documentation.
+ */
+
+/**
+ * Updates for v0.0.2
+ *
+ * Update entity definitions and reimport default configuration for
+ * so views-based display gets added.
+ */
+function site_documentation_update_9002() {
+  $config_factory = \Drupal::configFactory();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type_manager = \Drupal::service('entity_type.manager');
+  $config_installer = \Drupal::service('config.installer');
+
+  // Delete config for field_related_documentation.
+  $configs = [
+    'field.field.site_documentation.site_documentation.field_related_documentation',
+    'field.storage.site_documentation.field_related_documentation'
+  ];
+  foreach ($configs as $config) {
+    $field_config = $config_factory->getEditable($config);
+    if ($field_config) {
+      $field_config->delete();
+    }
+  }
+
+  // Update entity definition of site_documentation.
+  $sd_definition = $entity_type_manager->getDefinition('site_documentation');
+  $entity_definition_update_manager->updateEntityType($sd_definition);
+
+  // Install default configuration for module.
+  $config_installer->installDefaultConfig('module', 'site_documentation');
+
+}

--- a/site_documentation.module
+++ b/site_documentation.module
@@ -40,21 +40,26 @@ function site_documentation_theme($existing, $type, $theme, $path) {
  * Implements hook_entity_type_build().
  */
 function site_documentation_site_documentation_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  if ($build['#view_mode'] !== 'full') {
+  if ($build['#view_mode'] !== 'full'
+    || !$entity->hasField('field_documentation_topics')
+    || !$entity->get('field_documentation_topics')->isEmpty()
+    || !Views::getView('related_site_documents')
+  ) {
     return;
   }
 
-  $topics = $entity->get('field_documentation_topics')->getValue();
-  if (!empty($topics[0]['target_id'])) {
-    $args = [$topics[0]['target_id'], $entity->id()];
-    $view = Views::getView('related_site_documents');
-    if (is_object($view)) {
-      $view->setArguments($args);
-      $view->setDisplay('block_1');
-      $view->preExecute();
-      $view->execute();
-      $build['related_docs'] = $view->buildRenderable('block_1', $args);
-    }
+  $topics = array_map(function ($topic) {
+    return $topic['target_id'];
+  }, $entity->get('field_documentation_topics')->getValue());
+
+  if (!empty($topics)) {
+    $build['related_docs'] = [
+      '#type' => 'view',
+      '#name' => 'related_site_documents',
+      '#display_id' => 'block_1',
+      '#embed' => TRUE,
+      '#arguments' => [implode('+', $topics), $entity->id()],
+    ];
   }
 }
 
@@ -62,7 +67,6 @@ function site_documentation_site_documentation_view(array &$build, EntityInterfa
  * Add useful variables for template.
  */
 function site_documentation_preprocess_site_documentation(&$vars) {
-
   $vars['view_mode'] = $vars['elements']['#view_mode'];
   // Helpful $content variable for templates.
   $vars += ['content' => []];
@@ -75,14 +79,21 @@ function site_documentation_preprocess_site_documentation(&$vars) {
  * Implements hook_preprocess_HOOK().
  */
 function site_documentation_preprocess_help_section__site_documentation(&$vars) {
-  $vars['documents_view'] = get_all_documentations_view();
+  if (Views::getView('related_site_documents')) {
+    $vars['documents_view'] = [
+      '#type' => 'view',
+      '#name' => 'related_site_documents',
+      '#display_id' => 'block_2',
+      '#embed' => TRUE,
+      '#arguments' => [],
+    ];
+  }
 }
 
 /**
  * Implements hook_help_section_info_alter().
  */
 function site_documentation_help_section_info_alter(array &$info) {
-
   foreach ($info as $plugin_id => $plugin_info) {
     if (empty($info[$plugin_id]['permission'])) {
       $info[$plugin_id]['permission'] = 'access ' . $plugin_id . ' help section';
@@ -103,19 +114,4 @@ function site_documentation_theme_suggestions_alter(array &$suggestions, array $
     $suggestions[] = 'help_section__site_documentation';
     $variables['theme_hook_original'] = 'help_section__site_documentation';
   }
-}
-
-/**
- * Helper function. Gets all site documentations list renderable array
- * @return array|null
- */
-function get_all_documentations_view() {
-  $view = Views::getView('related_site_documents');
-  if (is_object($view)) {
-    $view->setDisplay('block_2');
-    $view->preExecute();
-    $view->execute();
-    return $view->buildRenderable('block_2', []);
-  }
-  return [];
 }

--- a/site_documentation.module
+++ b/site_documentation.module
@@ -42,7 +42,7 @@ function site_documentation_theme($existing, $type, $theme, $path) {
 function site_documentation_site_documentation_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   if ($build['#view_mode'] !== 'full'
     || !$entity->hasField('field_documentation_topics')
-    || !$entity->get('field_documentation_topics')->isEmpty()
+    || $entity->get('field_documentation_topics')->isEmpty()
     || !Views::getView('related_site_documents')
   ) {
     return;

--- a/src/Entity/SiteDocumentation.php
+++ b/src/Entity/SiteDocumentation.php
@@ -158,7 +158,6 @@ class SiteDocumentation extends EditorialContentEntityBase {
     return parent::save();
   }
 
-
   /**
    * {@inheritdoc}
    */
@@ -236,12 +235,6 @@ class SiteDocumentation extends EditorialContentEntityBase {
       ->setReadOnly(TRUE)
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE);
-
-    $fields['all_docs'] = BaseFieldDefinition::create('entity_reference')
-      ->setLabel('Computed Reference Field Test')
-      ->setComputed(TRUE)
-      ->setSetting('target_type', 'site_documentation')
-      ->setClass(DocsListing::class);
 
     return $fields;
   }

--- a/templates/site-documentation.html.twig
+++ b/templates/site-documentation.html.twig
@@ -22,14 +22,14 @@
         <div style="display: flex; justify-content: space-around">
             {% if content %}
                 <div style="width:75%; max-width: 600px;">
-                    {{content|without('related_docs', 'all_docs',  'field_documentation_topics')}}
+                    {{content|without('related_docs', 'field_documentation_topics')}}
                 </div>
             {% endif %}
 
             {% if content.related_docs %}
                 <div style="width:20%;">
                     <fieldset>
-                        <legend>{{ 'Related Documentations'|t }}</legend>
+                        <legend>{{ 'Related Documentation'|t }}</legend>
                         <div>
                             {{ content.related_docs }}
                         </div>


### PR DESCRIPTION
The work in #1 looks great. There are a few followup items I'm making here that I think will improve the flexibility and ease the deployment process a bit.

The biggest things were:
- Make the topic field required
- Add an update hook to avoid manual deployment steps
- Allow multiple topics to be used for related documentation view
- Add grouping to the view so the full listing now looks like this:
![Screen Shot 2022-02-10 at 11 29 20 AM](https://user-images.githubusercontent.com/1078156/153452135-d9a24b56-1eb1-4204-95bf-9a8a2f47a124.png)

Each change is in an individual commit and commented in the "files changed" section of this PR.

@aramgevorgyan86 Can you take a look, let me know if you have any questions, and then merge this into your pr if it looks good?